### PR TITLE
use standard textblock to explain DataLad datasets in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,45 +34,74 @@ ds000113d) <https://www.openfmri.org/dataset/ds000113d>`_.
 
 Alternatively, the `studyforrest phase 2 repository on GitHub
 <https://github.com/psychoinformatics-de/studyforrest-data-phase2>`_ provides
-fine-grained access, down to the level of individual files, and allow for
-tracking future updates.
+access as a DataLad dataset.
 
-This repository contains metadata and information on the identity of all
-included files. However, the actual content of the (sometime large) data
-files is stored elsewhere. To obtain any dataset component, git-annex_ is
-required in addition to Git_.
+DataLad datasets and how to use them
+------------------------------------
 
-1. Clone this repository to the desired location.
-2. Enter the directory with the local clone and run::
+This repository is a `DataLad <https://www.datalad.org/>`__ dataset. It provides
+fine-grained data access down to the level of individual files, and allows for
+tracking future updates up to the level of single files. In order to use
+this repository for data retrieval, `DataLad <https://www.datalad.org>`_ is
+required. It is a free and open source command line tool, available for all
+major operating systems, and builds up on Git and `git-annex
+<https://git-annex.branchable.com>`__ to allow sharing, synchronizing, and
+version controlling collections of large files. You can find information on
+how to install DataLad at `handbook.datalad.org/en/latest/intro/installation.html
+<http://handbook.datalad.org/en/latest/intro/installation.html>`_.
 
-     git annex init
+Get the dataset
+^^^^^^^^^^^^^^^
 
-   Older versions of git-annex may require you to run the following
-   command immediately afterwards::
+A DataLad dataset can be ``cloned`` by running::
 
-     git annex enableremote mddatasrc
+   datalad clone <url>
 
-Now any desired dataset component can be obtained by using the ``git annex get``
-command. To obtain the entire dataset content run::
+Once a dataset is cloned, it is a light-weight directory on your local machine.
+At this point, it contains only small metadata and information on the
+identity of the files in the dataset, but not actual *content* of the
+(sometimes large) data files.
 
-     git annex get .
+Retrieve dataset content
+^^^^^^^^^^^^^^^^^^^^^^^^
 
+After cloning a dataset, you can retrieve file contents by running::
 
-Keep data up-to-date
---------------------
+   datalad get <path/to/directory/or/file>
 
-If updates to this dataset are made in the future, update any local clone by
-running::
+This command will trigger a download of the files, directories, or
+subdatasets you have specified.
 
-     git pull
+DataLad datasets can contain other datasets, so called *subdatasets*. If you
+clone the top-level dataset, subdatasets do not yet contain metadata and
+information on the identity of files, but appear to be empty directories. In
+order to retrieve file availability metadata in subdatasets, run::
 
-followed by::
+   datalad get -n <path/to/subdataset>
 
-     git annex get .
+Afterwards, you can browse the retrieved metadata to find out about
+subdataset contents, and retrieve individual files with ``datalad get``. If you
+use ``datalad get <path/to/subdataset>``, all contents of the subdataset will
+be downloaded at once.
 
-to fetch all new files.
+Stay up-to-date
+^^^^^^^^^^^^^^^
 
+DataLad datasets can be updated. The command ``datalad update`` will *fetch*
+updates and store them on a different branch (by default
+``remotes/origin/master``). Running::
 
+   datalad update --merge
+
+will *pull* available updates and integrate them in one go.
+
+More information
+^^^^^^^^^^^^^^^^
+
+More information on DataLad and how to use it can be found in the DataLad Handbook at
+`handbook.datalad.org <http://handbook.datalad.org/en/latest/index.html>`_. The
+chapter "DataLad datasets" can help you to familiarize yourself with the
+concept of a dataset.
 
 
 .. _Git: http://www.git-scm.com


### PR DESCRIPTION
This replaces the git-annex based access notes with a standard textblock on what DataLad datasets are.