### PR TITLE
Add recursiveinstall skip configuration for private sourcedataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/lab-eyetracking"]
 	path = src/lab-eyetracking
 	url = /home/data/psyinf/forrest_gump/collection/fg_eyegaze_raw
+	datalad-recursiveinstall = skip


### PR DESCRIPTION
The eyetracking part of this dataset is build from a private sourcedataset with the raw eyetracking data that lives somewhere on our server. No-one without access to this server (and the registered url is even outdated as far as I can see -- points to a path on medusa) could retrieve it. 

To prevent cloning errors when one installs this dataset recursively, this PR adds the recursiveinstall skip configuration. This should prevent automatic recursion into further subdatasets, unless explicitly cloned by name. ping @mih 

This for example becomes relevant for a tutorial based on the remodnav paper, and surfaced in https://github.com/datalad-handbook/datalad-tutorial-binder/issues/1.